### PR TITLE
bump commons-compress from 1.21 to 1.26.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ implementation group: 'org.apache.commons', name: 'commons-configuration2', vers
 // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
 implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 // https://mvnrepository.com/artifact/org.apache.commons/commons-compress
-implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.21'
+implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
 implementation group:'com.ibm.fhir', name:'fhir-registry', version:'4.10.2'
 implementation group:'com.ibm.fhir', name:'fhir-term', version:'4.10.2'
 implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'


### PR DESCRIPTION
Mitigate Snyk [issue](https://app.snyk.io/org/hl7v2-fhir-converter-fork/project/21f59aa7-110f-4bfa-a947-66325220af0b#issue-SNYK-JAVA-ORGAPACHECOMMONS-6254296) and [issue](https://app.snyk.io/org/hl7v2-fhir-converter-fork/project/21f59aa7-110f-4bfa-a947-66325220af0b#issue-SNYK-JAVA-ORGAPACHECOMMONS-6254297).