### PR TITLE
Bump commons-configuration2 from 2.8.0 to 2.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ implementation group: 'org.thymeleaf', name: 'thymeleaf', version: '3.1.2.RELEAS
 implementation group: 'org.apache.commons', name: 'commons-jexl3', version: '3.1'
 implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.9.0'
 // https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2
-implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
+implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.10.1'
 // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
 implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 // https://mvnrepository.com/artifact/org.apache.commons/commons-compress


### PR DESCRIPTION
Update to mitigate [finding](https://app.snyk.io/org/hl7v2-fhir-converter-fork/project/21f59aa7-110f-4bfa-a947-66325220af0b#issue-SNYK-JAVA-ORGAPACHECOMMONS-6475528) and [finding](https://app.snyk.io/org/hl7v2-fhir-converter-fork/project/21f59aa7-110f-4bfa-a947-66325220af0b#issue-SNYK-JAVA-ORGAPACHECOMMONS-6475534)