### PR TITLE
13976: optionally rethrow error

### DIFF
--- a/src/main/java/io/github/linuxforhealth/api/MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/api/MessageEngine.java
@@ -36,6 +36,13 @@ public interface MessageEngine {
    */
   FHIRContext getFHIRContext();
 
+  /**
+   * Returns whether an exception that occurs during conversion should be logged or logged and rethrown
+   *
+   * @return boolean
+   */
+  boolean getShouldRethrowConversionException();
+
 
   }
 

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageEngine.java
@@ -62,6 +62,7 @@ public class HL7MessageEngine implements MessageEngine {
     private static final ObjectMapper OBJ_MAPPER = ObjectMapperUtil.getJSONInstance();
     private FHIRContext context;
     private BundleType bundleType;
+    private boolean shouldRethrowConversionException = false;
 
     /**
      * 
@@ -79,6 +80,12 @@ public class HL7MessageEngine implements MessageEngine {
     public HL7MessageEngine(FHIRContext context, BundleType bundleType) {
         this.context = context;
         this.bundleType = bundleType;
+    }
+
+    public HL7MessageEngine(FHIRContext context, BundleType bundleType, boolean rethrowConversionException) {
+        this.context = context;
+        this.bundleType = bundleType;
+        this.shouldRethrowConversionException = rethrowConversionException;
     }
 
     /**
@@ -348,5 +355,10 @@ public class HL7MessageEngine implements MessageEngine {
     @Override
     public FHIRContext getFHIRContext() {
         return context;
+    }
+
+    @Override
+    public boolean getShouldRethrowConversionException() {
+        return this.shouldRethrowConversionException;
     }
 }

--- a/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageModel.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/message/HL7MessageModel.java
@@ -97,6 +97,9 @@ public class HL7MessageModel implements MessageTemplate<Message> {
         } catch (Exception e) {
             // Print stack class and trace without the error message.
             handleException(e);
+            if(engine.getShouldRethrowConversionException()) {
+                throw e;
+            }
         }
 
         return bundle;


### PR DESCRIPTION
This PR adds an additional flag that can be set on the engine to re-throw any encountered exceptions